### PR TITLE
tweak(regex): Parsing improved for "Extras.yml".

### DIFF
--- a/regex_patterns/Extras.yml
+++ b/regex_patterns/Extras.yml
@@ -1,5 +1,5 @@
 name: Extras
-pattern: (?i)(\b|\.)(extra[s]?|special feature[s]?)\b
+pattern: (?i)(?<=\b[12]\d{3}\b).*(\b|\.)\b(Extras?|Bonus|Extended[ ._-]Clip|Special Feature[s]?)\b
 description: Extras, Special Features, Featurettes, etc
 tags:
 - Unwanted


### PR DESCRIPTION
Hi Santiago!
It's my first PR in my life so I hope I am doing it right.

I noticed that the Extras CF had a false positive on one of my releases of "E.T. the Extra-Terrestial". It was mainly due to poor naming of one of my spanish indexers but I thought it could be improved to avoid it, even when the name of the movie is tricky.

I basically merged a combination between your's and TRaSH's. Let me know it you interested!