### PR TITLE
fix(regex): match literal `.` rather than any character

### DIFF
--- a/regex_patterns/7.1 Surround.yml
+++ b/regex_patterns/7.1 Surround.yml
@@ -1,5 +1,5 @@
 name: 7.1 Surround
-pattern: '7.1'
+pattern: '7\.1'
 description: ''
 tags:
 - Audio


### PR DESCRIPTION
The \\. is still important to escape the period, so it matches a literal period and not any character.

It will now only match "7.1" and not "7x1"