### PR TITLE
fix(format): HDR improvements

### DIFF
--- a/custom_formats/HDR.yml
+++ b/custom_formats/HDR.yml
@@ -1,0 +1,12 @@
+name: HDR
+description: Matches the 'HDR' Regex Pattern
+tags:
+- Colour Grade
+- HDR
+conditions:
+- name: HDR
+  negate: false
+  pattern: HDR
+  required: true
+  type: release_title
+tests: []

--- a/custom_formats/HDR.yml
+++ b/custom_formats/HDR.yml
@@ -9,4 +9,14 @@ conditions:
   pattern: HDR
   required: true
   type: release_title
+- name: Not HDR10
+  type: release_title
+  required: true
+  negate: true
+  pattern: HDR10
+- name: Not HDR10+
+  type: release_title
+  required: true
+  negate: true
+  pattern: HDR10+
 tests: []

--- a/custom_formats/HDR10 (Missing) (1080p).yml
+++ b/custom_formats/HDR10 (Missing) (1080p).yml
@@ -4,6 +4,11 @@ tags:
 - Colour Grade
 - HDR
 conditions:
+- name: Blu-ray
+  type: source
+  required: true
+  negate: false
+  source: bluray
 - name: 1080p
   negate: false
   required: true
@@ -32,6 +37,11 @@ conditions:
 - name: Not HDR10
   negate: true
   pattern: HDR10
+  required: true
+  type: release_title
+- name: Not HDR
+  negate: true
+  pattern: HDR
   required: true
   type: release_title
 tests: []

--- a/custom_formats/HDR10 (Missing).yml
+++ b/custom_formats/HDR10 (Missing).yml
@@ -30,6 +30,11 @@ conditions:
   pattern: SDR
   required: true
   type: release_title
+- name: Not HDR
+  type: release_title
+  required: true
+  negate: true
+  pattern: HDR
 tests:
 - conditionResults:
   - matches: false

--- a/custom_formats/HDR10 (Missing).yml
+++ b/custom_formats/HDR10 (Missing).yml
@@ -1,19 +1,20 @@
 name: HDR10 (Missing)
-description: Attempts to match HDR10 to groups that mislabel their releases
+description: Attempts to match HDR10 to groups that mislabel their releases. *This
+  does not work properly in sonarr.*
 tags:
 - Colour Grade
 - HDR
 conditions:
+- name: Blu-ray
+  negate: false
+  required: true
+  source: bluray
+  type: source
 - name: 2160p
   negate: false
   required: true
   resolution: 2160p
   type: resolution
-- name: Blu-ray
-  type: source
-  required: true
-  negate: false
-  source: bluray
 - name: Not HDR10
   negate: true
   pattern: HDR10

--- a/custom_formats/HDR10.yml
+++ b/custom_formats/HDR10.yml
@@ -9,4 +9,9 @@ conditions:
   pattern: HDR10
   required: true
   type: release_title
+- name: Not HDR10+
+  type: release_title
+  required: true
+  negate: true
+  pattern: HDR10+
 tests: []

--- a/custom_formats/SDR.yml
+++ b/custom_formats/SDR.yml
@@ -5,28 +5,33 @@ tags:
 - HDR
 conditions:
 - name: 2160p
-  type: resolution
-  required: true
   negate: false
+  required: true
   resolution: 2160p
+  type: resolution
 - name: WEB-DL
-  type: source
-  required: true
   negate: false
-  source: web_dl
-- name: Not HDR10+
-  type: release_title
   required: true
+  source: web_dl
+  type: source
+- name: Not HDR10+
   negate: true
   pattern: HDR10+
-- name: Not Dolby Vision
-  type: release_title
   required: true
+  type: release_title
+- name: Not Dolby Vision
   negate: true
   pattern: Dolby Vision
+  required: true
+  type: release_title
 - name: Not HDR10
   negate: true
   pattern: HDR10
   required: true
   type: release_title
+- name: Not HDR
+  type: release_title
+  required: true
+  negate: true
+  pattern: HDR
 tests: []

--- a/custom_formats/Unknown Lossless Audio.yml
+++ b/custom_formats/Unknown Lossless Audio.yml
@@ -6,25 +6,25 @@ tags:
 - Audio
 conditions:
 - name: 2160p
-  type: resolution
-  required: true
   negate: false
+  required: true
   resolution: 2160p
+  type: resolution
 - name: Blu-ray
-  type: source
-  required: true
   negate: false
-  source: bluray
-- name: Not DTS-HD MA
-  type: release_title
   required: true
+  source: bluray
+  type: source
+- name: Not DTS-HD MA
   negate: true
   pattern: DTS-HD MA
-- name: Not DTS-X
-  type: release_title
   required: true
+  type: release_title
+- name: Not DTS-X
   negate: true
   pattern: DTS-X
+  required: true
+  type: release_title
 - name: Not FLAC
   negate: true
   pattern: FLAC
@@ -45,9 +45,9 @@ conditions:
   pattern: DTS
   required: true
   type: release_title
-- name: Not TrueHD + Atmos
+- name: Not TrueHD
   negate: true
-  pattern: TrueHD + Atmos
+  pattern: TrueHD
   required: true
   type: release_title
 - name: Not Dolby Digital

--- a/custom_formats/Unknown Lossless Audio.yml
+++ b/custom_formats/Unknown Lossless Audio.yml
@@ -60,4 +60,9 @@ conditions:
   pattern: Dolby Digital +
   required: true
   type: release_title
+- name: Not Missing Group
+  type: release_title
+  required: true
+  negate: true
+  pattern: TrueHD (Missing Groups)
 tests: []

--- a/profiles/1080p Balanced.yml
+++ b/profiles/1080p Balanced.yml
@@ -120,9 +120,13 @@ custom_formats:
   score: -9999
 - name: h265 (Missing)
   score: -9999
+- name: HDR
+  score: -9999
 - name: HDR10
   score: -9999
 - name: HDR10 (Missing)
+  score: -9999
+- name: HDR10 (Missing) (1080p)
   score: -9999
 - name: HDR10+
   score: -9999

--- a/profiles/1080p Quality (HDR).yml
+++ b/profiles/1080p Quality (HDR).yml
@@ -89,9 +89,9 @@ custom_formats:
   score: 10
 - name: Blu-ray
   score: 10
-- name: HDR10
+- name: HDR
   score: 10
-- name: HDR10 (Missing)
+- name: HDR10
   score: 10
 - name: HDR10 (Missing) (1080p)
   score: 10
@@ -134,6 +134,8 @@ custom_formats:
 - name: h265
   score: -9999
 - name: h265 (Missing)
+  score: -9999
+- name: Non Retail HDR
   score: -9999
 - name: Remux
   score: -9999

--- a/profiles/1080p Quality.yml
+++ b/profiles/1080p Quality.yml
@@ -114,9 +114,13 @@ custom_formats:
   score: -9999
 - name: h265 (Missing)
   score: -9999
+- name: HDR
+  score: -9999
 - name: HDR10
   score: -9999
 - name: HDR10 (Missing)
+  score: -9999
+- name: HDR10 (Missing) (1080p)
   score: -9999
 - name: HDR10+
   score: -9999

--- a/profiles/1080p Remux.yml
+++ b/profiles/1080p Remux.yml
@@ -104,6 +104,8 @@ custom_formats:
   score: -9999
 - name: h265 (Missing)
   score: -9999
+- name: HDR
+  score: -9999
 - name: HDR10
   score: -9999
 - name: HDR10 (Missing)

--- a/profiles/2160p Balanced.yml
+++ b/profiles/2160p Balanced.yml
@@ -94,6 +94,8 @@ custom_formats:
   score: 10
 - name: Blu-ray
   score: 10
+- name: HDR
+  score: 10
 - name: HDR10
   score: 10
 - name: HDR10 (Missing)
@@ -132,32 +134,6 @@ custom_formats:
   score: 5
 - name: Unknown Lossless Audio
   score: 5
-- name: Amazon Prime
-  score: 0
-- name: Apple TV+
-  score: 0
-- name: Criterion Channel
-  score: 0
-- name: Disney+
-  score: 0
-- name: HBO Max
-  score: 0
-- name: Hulu
-  score: 0
-- name: iTunes
-  score: 0
-- name: Max
-  score: 0
-- name: Movies Anywhere
-  score: 0
-- name: Netflix
-  score: 0
-- name: Paramount+
-  score: 0
-- name: Peacock
-  score: 0
-- name: Roku
-  score: 0
 - name: SDR
   score: -80
 - name: 2160p Blu-ray Encode

--- a/profiles/2160p Quality.yml
+++ b/profiles/2160p Quality.yml
@@ -107,6 +107,8 @@ custom_formats:
   score: 10
 - name: Blu-ray
   score: 10
+- name: HDR
+  score: 10
 - name: HDR10
   score: 10
 - name: HDR10 (Missing)
@@ -145,32 +147,6 @@ custom_formats:
   score: 5
 - name: Unknown Lossless Audio
   score: 5
-- name: Amazon Prime
-  score: 0
-- name: Apple TV+
-  score: 0
-- name: Criterion Channel
-  score: 0
-- name: Disney+
-  score: 0
-- name: HBO Max
-  score: 0
-- name: Hulu
-  score: 0
-- name: iTunes
-  score: 0
-- name: Max
-  score: 0
-- name: Movies Anywhere
-  score: 0
-- name: Netflix
-  score: 0
-- name: Paramount+
-  score: 0
-- name: Peacock
-  score: 0
-- name: Roku
-  score: 0
 - name: SDR
   score: -80
 - name: x265

--- a/profiles/2160p Remux.yml
+++ b/profiles/2160p Remux.yml
@@ -72,6 +72,8 @@ custom_formats:
   score: 10
 - name: Atmos (Missing)
   score: 10
+- name: HDR
+  score: 10
 - name: HDR10
   score: 10
 - name: HDR10 (Missing)
@@ -113,6 +115,8 @@ custom_formats:
 - name: h265
   score: -9999
 - name: h265 (Missing)
+  score: -9999
+- name: HDR10 (Missing) (1080p)
   score: -9999
 - name: Non Retail HDR
   score: -9999

--- a/regex_patterns/HDR.yml
+++ b/regex_patterns/HDR.yml
@@ -1,9 +1,7 @@
 name: HDR
-pattern: (?<=^(?!.*\b(HLG|PQ|SDR)(\b|\d)).*?)\bHDR(?!10(\+|Plus)?)\b
-description: 'This regex matches a `HDR` generalisation. i.e. only when it *is not*
-  followed by any HDR format specifiers like ,  `10+`, or `10Plus` and only when `HLG`,
-  `PQ` and `SDR` cannot be found. When matched, this pattern indicates an unknown
-  type of HDR - it can either by 10 or 10+. '
+pattern: \b(HDR)\b
+description: 'This regex matches a `HDR` generalisation. This can be HDR10, HDR10+,
+  etc. '
 tags:
 - Enhancement
 - Colour Grade
@@ -12,20 +10,18 @@ tests:
 - expected: true
   id: 2
   input: HDR+
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan:
     end: 3
     start: 0
   matchedContent: HDR
   matchedGroups:
-  - null
-  - null
-  - null
+  - HDR
   passes: true
 - expected: false
   id: 3
   input: HDR10
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -33,31 +29,7 @@ tests:
 - expected: false
   id: 4
   input: HDR10+
-  lastRun: '2025-04-02T20:12:32.851228'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
-  passes: true
-- expected: false
-  id: 5
-  input: HLG HDR
-  lastRun: '2025-04-02T20:12:32.851228'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
-  passes: true
-- expected: false
-  id: 6
-  input: SDR HDR
-  lastRun: '2025-04-02T20:12:32.851228'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
-  passes: true
-- expected: false
-  id: 7
-  input: PQ HDR
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -65,7 +37,7 @@ tests:
 - expected: false
   id: 8
   input: HDR10
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -74,35 +46,31 @@ tests:
   id: 9
   input: Barbie (2023) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR TrueHD Atmos 7.1
     English-FraMeSToR
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan:
     end: 55
     start: 52
   matchedContent: HDR
   matchedGroups:
-  - null
-  - null
-  - null
+  - HDR
   passes: true
 - expected: true
   id: 10
   input: Game of Thrones (2011) S06 2160p UHD BluRay REMUX HEVC DV HDR TrueHD Atmos
     7.1 English-FraMeSToR
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan:
     end: 61
     start: 58
   matchedContent: HDR
   matchedGroups:
-  - null
-  - null
-  - null
+  - HDR
   passes: true
 - expected: false
   id: 11
   input: Liu lang di qiu 2 AKA The Wandering Earth II 2023 2160p CHN UHD Blu-ray DoVi
     HDR10 HEVC TrueHD 7.1 Atmos-ANKO
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -111,7 +79,7 @@ tests:
   id: 12
   input: Schindler's List (1993) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR10+ TrueHD
     Atmos 7.1 English-WiLDCAT
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -120,7 +88,7 @@ tests:
   id: 13
   input: Schindler's List (1993) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR10P TrueHD
     Atmos 7.1 English-WiLDCAT
-  lastRun: '2025-04-02T20:12:32.851228'
+  lastRun: '2025-04-03T04:14:14.836165'
   matchSpan: null
   matchedContent: null
   matchedGroups: []

--- a/regex_patterns/HDR.yml
+++ b/regex_patterns/HDR.yml
@@ -1,34 +1,39 @@
-name: HDR10
-pattern: \bHDR10(?!\+|Plus)\b
-description: 'This regex matches `HDR10` only when it *is not* followed by any HDR
-  format specifiers like `+`, or `Plus`. '
+name: HDR
+pattern: (?<=^(?!.*\b(HLG|PQ|SDR)(\b|\d)).*?)\bHDR(?!10(\+|Plus)?)\b
+description: 'This regex matches a `HDR` generalisation. i.e. only when it *is not*
+  followed by any HDR format specifiers like ,  `10+`, or `10Plus` and only when `HLG`,
+  `PQ` and `SDR` cannot be found. When matched, this pattern indicates an unknown
+  type of HDR - it can either by 10 or 10+. '
 tags:
 - Enhancement
 - Colour Grade
 - HDR
 tests:
-- expected: false
+- expected: true
   id: 2
   input: HDR+
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan:
+    end: 3
+    start: 0
+  matchedContent: HDR
+  matchedGroups:
+  - null
+  - null
+  - null
   passes: true
-- expected: true
+- expected: false
   id: 3
   input: HDR10
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan:
-    end: 5
-    start: 0
-  matchedContent: HDR10
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan: null
+  matchedContent: null
   matchedGroups: []
   passes: true
 - expected: false
   id: 4
   input: HDR10+
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -36,7 +41,7 @@ tests:
 - expected: false
   id: 5
   input: HLG HDR
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -44,7 +49,7 @@ tests:
 - expected: false
   id: 6
   input: SDR HDR
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -52,55 +57,61 @@ tests:
 - expected: false
   id: 7
   input: PQ HDR
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan: null
+  matchedContent: null
+  matchedGroups: []
+  passes: true
+- expected: false
+  id: 8
+  input: HDR10
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
   passes: true
 - expected: true
-  id: 8
-  input: HDR10
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan:
-    end: 5
-    start: 0
-  matchedContent: HDR10
-  matchedGroups: []
-  passes: true
-- expected: false
   id: 9
   input: Barbie (2023) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR TrueHD Atmos 7.1
     English-FraMeSToR
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan:
+    end: 55
+    start: 52
+  matchedContent: HDR
+  matchedGroups:
+  - null
+  - null
+  - null
   passes: true
-- expected: false
+- expected: true
   id: 10
   input: Game of Thrones (2011) S06 2160p UHD BluRay REMUX HEVC DV HDR TrueHD Atmos
     7.1 English-FraMeSToR
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan: null
-  matchedContent: null
-  matchedGroups: []
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan:
+    end: 61
+    start: 58
+  matchedContent: HDR
+  matchedGroups:
+  - null
+  - null
+  - null
   passes: true
-- expected: true
+- expected: false
   id: 11
   input: Liu lang di qiu 2 AKA The Wandering Earth II 2023 2160p CHN UHD Blu-ray DoVi
     HDR10 HEVC TrueHD 7.1 Atmos-ANKO
-  lastRun: '2025-04-02T20:01:38.732592'
-  matchSpan:
-    end: 82
-    start: 77
-  matchedContent: HDR10
+  lastRun: '2025-04-02T20:12:32.851228'
+  matchSpan: null
+  matchedContent: null
   matchedGroups: []
   passes: true
 - expected: false
   id: 12
   input: Schindler's List (1993) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR10+ TrueHD
     Atmos 7.1 English-WiLDCAT
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -109,7 +120,7 @@ tests:
   id: 13
   input: Schindler's List (1993) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR10P TrueHD
     Atmos 7.1 English-WiLDCAT
-  lastRun: '2025-04-02T20:01:38.732592'
+  lastRun: '2025-04-02T20:12:32.851228'
   matchSpan: null
   matchedContent: null
   matchedGroups: []

--- a/regex_patterns/HDR10+.yml
+++ b/regex_patterns/HDR10+.yml
@@ -1,10 +1,7 @@
 name: HDR10+
-pattern: (?<=^(?!.*\b(HLG|PQ|SDR)(\b|\d)).*?)HDR10(\+|P(lus)?)
-description: This regex matches "HDR10" when followed by either a plus sign ("+"),
-  "P", or "Plus", but only in strings that don't contain "HLG", "PQ", or "SDR" (when
-  followed by either a word boundary or digit) anywhere in the text. In other words,
-  it finds references to HDR10+ or HDR10Plus variants while excluding strings that
-  mention other HDR-related technologies.
+pattern: \bHDR10(\+|P(lus)?\b)
+description: This regex matches `HDR10` when followed by either a plus sign `+`, `P`,
+  or `Plus`
 tags:
 - Enhancement
 - Colour Grade
@@ -13,7 +10,7 @@ tests:
 - expected: false
   id: 1
   input: HDR
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -21,7 +18,7 @@ tests:
 - expected: false
   id: 2
   input: HDR+
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -29,7 +26,7 @@ tests:
 - expected: false
   id: 3
   input: HDR10
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -37,21 +34,19 @@ tests:
 - expected: true
   id: 4
   input: HDR10+
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan:
     end: 6
     start: 0
   matchedContent: HDR10+
   matchedGroups:
-  - null
-  - null
   - +
   - null
   passes: true
 - expected: false
   id: 5
   input: HLG HDR
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -59,7 +54,7 @@ tests:
 - expected: false
   id: 6
   input: SDR HDR
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -67,7 +62,7 @@ tests:
 - expected: false
   id: 7
   input: PQ HDR
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []
@@ -75,28 +70,24 @@ tests:
 - expected: true
   id: 8
   input: HDR10P
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan:
     end: 6
     start: 0
   matchedContent: HDR10P
   matchedGroups:
-  - null
-  - null
   - P
   - null
   passes: true
 - expected: true
   id: 9
   input: HDR10Plus
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan:
     end: 9
     start: 0
   matchedContent: HDR10Plus
   matchedGroups:
-  - null
-  - null
   - Plus
   - lus
   passes: true
@@ -104,14 +95,12 @@ tests:
   id: 10
   input: Schindler's List (1993) 2160p UHD BluRay Hybrid REMUX HEVC DV HDR10+ TrueHD
     Atmos 7.1 English-WiLDCAT
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan:
     end: 68
     start: 62
   matchedContent: HDR10+
   matchedGroups:
-  - null
-  - null
   - +
   - null
   passes: true
@@ -119,14 +108,12 @@ tests:
   id: 11
   input: La Maison S01 REPACK 2160p ATVP WEB-DL Dual-Audio DD+ 5.1 Atmos DV HDR10+
     H.265-Kitsune
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan:
     end: 73
     start: 67
   matchedContent: HDR10+
   matchedGroups:
-  - null
-  - null
   - +
   - null
   passes: true
@@ -134,7 +121,7 @@ tests:
   id: 12
   input: Liu lang di qiu 2 AKA The Wandering Earth II 2023 2160p CHN UHD Blu-ray DoVi
     HDR10 HEVC TrueHD 7.1 Atmos-ANKO
-  lastRun: '2024-12-13T09:52:40.529508'
+  lastRun: '2025-04-02T20:02:13.896309'
   matchSpan: null
   matchedContent: null
   matchedGroups: []


### PR DESCRIPTION
- fixed a issue where HDR was matching both HDR10 & 10+
- fixed an issue where unknown lossless audio was matching for TrueHD releases / missing groups
- added a new 'general HDR' CF which matches HDR that isn't HDR10 nor HDR10+
