### PR TITLE
feat(profile): Add French 1080p Efficient profiles for Sonarr/Radarr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+Ce fichier guide Claude Code (claude.ai/code) pour travailler sur ce dépôt.
+
+## Présentation
+
+Fork de la [Dictionarry Database](https://github.com/Dictionarry-Hub/database) (base YAML Profilarr pour Radarr/Sonarr). Ce fork ajoute du contenu personnalisé (notamment français) tout en restant synchronisable avec l'upstream.
+
+## Règle fondamentale : ne jamais modifier les fichiers upstream
+
+Ce repo est synchronisé avec `upstream` (Dictionarry-Hub/database). Pour garantir des merges sans conflit :
+
+- **INTERDIT** de modifier ou supprimer un fichier existant venant d'upstream
+- **Uniquement ajouter de nouveaux fichiers**
+- Les ajouts français sont préfixés `FR - ` (ex: `FR - Multi.yml`, `FR - VFF.yml`)
+- Les ajouts généraux utilisent un nom unique qui n'existe pas upstream
+
+## Synchronisation upstream
+
+```bash
+git fetch upstream
+git merge upstream/stable
+```
+
+Le remote `upstream` pointe vers `https://github.com/Dictionarry-Hub/database.git`.
+
+## Structure du dépôt
+
+- `regex_patterns/` — Définitions de patterns regex avec cas de test intégrés
+- `custom_formats/` — Définitions de formats personnalisés référençant les patterns regex via des conditions
+- `profiles/` — Profils qualité combinant des formats personnalisés avec des scores (`custom_formats_radarr`, `custom_formats_sonarr`)
+- `media_management/` — Conventions de nommage, définitions de qualité, paramètres divers
+- `templates/` — Templates YAML pour `tierCreator.py`
+- `scripts/tierCreator.py` — Génère des formats personnalisés et patterns regex par tier depuis un JSON
+
+## Script tierCreator
+
+```bash
+python3 scripts/tierCreator.py <json_file> --resolution <SD|720p|1080p|2160p> --type <Quality|Balanced> [--dry-run]
+```
+
+## Schémas YAML
+
+**Pattern regex** (`regex_patterns/*.yml`) :
+```yaml
+name: PatternName
+pattern: regex_string
+description: Ce que ça matche
+tags: [Catégorie]
+tests:
+- expected: true/false
+  id: integer
+  input: chaîne_de_test
+  matchSpan: {start: int, end: int}
+  matchedContent: string
+  passes: boolean
+```
+
+**Format personnalisé** (`custom_formats/*.yml`) :
+```yaml
+name: FormatName
+description: Ce que ça matche
+tags: [Catégorie, SousCatégorie]
+conditions:
+- name: NomCondition
+  negate: false
+  pattern: RéférencePattern
+  required: true/false
+  type: release_title|release_group|source|resolution
+tests: []
+```
+
+**Profil** (`profiles/*.yml`) :
+```yaml
+name: Résolution Stratégie
+description: ...
+tags: [résolution, stratégie]
+upgradesAllowed: true
+minCustomFormatScore: integer
+custom_formats:
+- name: NomFormat
+  score: integer
+qualities:
+- id: integer
+  name: NomQualité
+```
+
+## Format des commits
+
+Format : `type(component): Description`
+
+**Types** : `create` (nouveau), `add` (ajout à un système existant), `tweak` (ajustement), `fix` (correction), `delete` (suppression)
+
+**Components** : `format`, `regex`, `profile`
+
+## Workflow Git
+
+- `stable` est la branche principale
+- `upstream/stable` est la source de vérité pour le contenu Dictionarry

--- a/custom_formats/FR - Multi.yml
+++ b/custom_formats/FR - Multi.yml
@@ -1,0 +1,12 @@
+name: FR - Multi
+description: Matches releases tagged MULTi (multiple audio tracks)
+tags:
+- Language
+- French
+conditions:
+- name: Multi
+  negate: false
+  pattern: FR - Multi
+  required: true
+  type: release_title
+tests: []

--- a/custom_formats/FR - Not Multi.yml
+++ b/custom_formats/FR - Not Multi.yml
@@ -1,0 +1,12 @@
+name: FR - Not Multi
+description: Matches releases that do NOT have the MULTi tag
+tags:
+- Language
+- French
+conditions:
+- name: Not Multi
+  negate: true
+  pattern: FR - Multi
+  required: true
+  type: release_title
+tests: []

--- a/custom_formats/FR - VF Only.yml
+++ b/custom_formats/FR - VF Only.yml
@@ -1,0 +1,18 @@
+name: FR - VF Only
+description: Matches releases with French version markers that are NOT Multi (VF without
+  VO)
+tags:
+- Language
+- French
+conditions:
+- name: VF
+  negate: false
+  pattern: FR - VF
+  required: true
+  type: release_title
+- name: Not Multi
+  negate: true
+  pattern: FR - Multi
+  required: true
+  type: release_title
+tests: []

--- a/custom_formats/FR - VFQ.yml
+++ b/custom_formats/FR - VFQ.yml
@@ -1,0 +1,12 @@
+name: FR - VFQ
+description: Matches releases tagged with Quebec French version (VFQ)
+tags:
+- Language
+- French
+conditions:
+- name: VFQ
+  negate: false
+  pattern: FR - VFQ
+  required: true
+  type: release_title
+tests: []

--- a/profiles/FR - 1080p VO Efficient.yml
+++ b/profiles/FR - 1080p VO Efficient.yml
@@ -1,0 +1,344 @@
+name: FR - 1080p VO Efficient
+description: '1080p Efficient targeting VO (original version) releases only. Based
+  on 1080p Efficient.
+
+
+  - VF-only releases are hard-blocked
+
+  - MULTi and VO releases are accepted
+
+  - Average TV Sizes ~ 2 to 3gb per Episode'
+tags:
+- 1080p
+- Efficient Focused
+- Lossy Audio
+- h265
+- x265
+- French
+upgradesAllowed: true
+minCustomFormatScore: 20000
+upgradeUntilScore: 888888
+minScoreIncrement: 1
+custom_formats:
+- name: 1080p Bluray HEVC Tier 1
+  score: 360000
+- name: HONE Bluray
+  score: 360000
+- name: 1080p WEB-DL HEVC Tier 1
+  score: 340000
+- name: HONE WEB
+  score: 340000
+- name: 1080p WEB-DL (h264)
+  score: 280000
+- name: 720p WEB-DL
+  score: 240000
+- name: 720p Bluray
+  score: 180000
+- name: 720p WEBRip
+  score: 180000
+- name: 576p Bluray
+  score: 120000
+- name: 720p Quality Tier 1
+  score: 85000
+- name: 720p Quality Tier 2
+  score: 84000
+- name: 720p Quality Tier 3
+  score: 83000
+- name: 720p Quality Tier 4
+  score: 82000
+- name: 720p Quality Tier 5
+  score: 81000
+- name: 480p Bluray
+  score: 80000
+- name: 720p Quality Tier 6
+  score: 80000
+- name: 480p WEB-DL
+  score: 60000
+- name: 576p Quality Tier 1
+  score: 43000
+- name: 576p Quality Tier 2
+  score: 42000
+- name: 576p Quality Tier 3
+  score: 41000
+- name: 576p Quality Tier 4
+  score: 40000
+- name: 480p Quality Tier 1
+  score: 23000
+- name: 480p Quality Tier 2
+  score: 22000
+- name: 480p Quality Tier 3
+  score: 21000
+- name: 480p Quality Tier 4
+  score: 20000
+- name: DVD
+  score: 20000
+- name: DVD Remux
+  score: 20000
+- name: SD Quality Tier 1
+  score: 11000
+- name: SD Quality Tier 2
+  score: 10000
+- name: AMZN
+  score: 3000
+- name: Dolby Vision
+  score: 3000
+- name: DSNP
+  score: 3000
+- name: ATVP
+  score: 2000
+- name: HDR10+
+  score: 2000
+- name: HMAX
+  score: 2000
+- name: MAX
+  score: 2000
+- name: DS4K
+  score: 1000
+- name: HDR
+  score: 1000
+- name: HDR10
+  score: 1000
+- name: HLG
+  score: 1000
+- name: iT
+  score: 1000
+- name: NF
+  score: 1000
+- name: PQ
+  score: 1000
+- name: FLAC
+  score: 800
+- name: DTS-HD HRA
+  score: 700
+- name: Opus
+  score: 700
+- name: Dolby Digital +
+  score: 600
+- name: DTS-ES
+  score: 500
+- name: Dolby Atmos
+  score: 400
+- name: Dolby Digital
+  score: 400
+- name: DTS
+  score: 300
+- name: AAC
+  score: 200
+- name: WEB-DL Tier 1
+  score: 100
+- name: WEB-DL Tier 2
+  score: 80
+- name: WEB-DL Tier 3
+  score: 60
+- name: WEB-DL Tier 4
+  score: 40
+- name: WEB-DL Tier 5
+  score: 20
+- name: Repack3
+  score: 8
+- name: Repack2
+  score: 7
+- name: Repack1
+  score: 6
+- name: CRAV
+  score: 0
+- name: CRIT
+  score: 0
+- name: DRPO
+  score: 0
+- name: HTSR
+  score: 0
+- name: HULU
+  score: 0
+- name: iP
+  score: 0
+- name: MUBI
+  score: 0
+- name: NOW
+  score: 0
+- name: PCOK
+  score: 0
+- name: PLAY
+  score: 0
+- name: PMTP
+  score: 0
+- name: ROKU
+  score: 0
+- name: SHO
+  score: 0
+- name: STAN
+  score: 0
+- name: ASL
+  score: -999999
+- name: AV1
+  score: -999999
+- name: Banned Groups (Efficient)
+  score: -999999
+- name: Banned WEBRip (Efficient)
+  score: -999999
+- name: BCORE
+  score: -999999
+- name: Dolby Vision (Without Fallback)
+  score: -999999
+- name: FR - VF Only
+  score: -999999
+- name: FR - VFQ
+  score: -999999
+- name: Full Disc
+  score: -999999
+- name: h265 (Efficient)
+  score: -999999
+- name: Lossless Audio
+  score: -999999
+- name: Remux
+  score: -999999
+- name: VP9
+  score: -999999
+- name: VVC
+  score: -999999
+- name: x265 (Efficient)
+  score: -999999
+- name: Xvid
+  score: -999999
+custom_formats_radarr:
+- name: 1080p Efficient Movie Bluray Tier 1
+  score: 323000
+- name: QxR Bluray
+  score: 323000
+- name: TAoE Bluray
+  score: 323000
+- name: 1080p Efficient Movie Bluray Tier 2
+  score: 322000
+- name: Vialle Bluray
+  score: 322000
+- name: 1080p Efficient Movie Bluray Tier 3
+  score: 321000
+- name: 1080p Efficient Movie Bluray Tier 4
+  score: 320000
+- name: 1080p Efficient Movie WEB Tier 1
+  score: 303000
+- name: QxR WEB
+  score: 303000
+- name: TAoE WEB
+  score: 303000
+- name: Weasley WEB
+  score: 303000
+- name: 1080p Efficient Movie WEB Tier 2
+  score: 302000
+- name: 1080p Efficient Movie WEB Tier 3
+  score: 301000
+- name: 1080p Efficient Movie WEB Tier 4
+  score: 300000
+- name: 1080p Balanced Tier 1
+  score: 281000
+- name: 1080p Balanced Tier 2
+  score: 280000
+- name: 720p Balanced Tier 1
+  score: 60000
+- name: MA
+  score: 4000
+- name: Better Theatricals
+  score: 1000
+- name: Special Edition
+  score: 1000
+- name: 3D
+  score: -999999
+- name: B&W
+  score: -999999
+- name: Extras
+  score: -999999
+- name: Full Disc (Quality Match)
+  score: -999999
+- name: Remux (Quality Match)
+  score: -999999
+- name: Sing Along
+  score: -999999
+- name: Upscale
+  score: -999999
+custom_formats_sonarr:
+- name: 1080p Efficient TV Bluray Tier 1
+  score: 324000
+- name: QxR Bluray
+  score: 324000
+- name: TAoE Bluray
+  score: 324000
+- name: Vialle Bluray
+  score: 324000
+- name: 1080p Efficient TV Bluray Tier 2
+  score: 323000
+- name: 1080p Efficient TV Bluray Tier 3
+  score: 322000
+- name: 1080p Efficient TV Bluray Tier 4
+  score: 321000
+- name: 1080p Efficient TV Bluray Tier 5
+  score: 320000
+- name: 1080p Efficient TV WEB Tier 1
+  score: 305000
+- name: QxR WEB
+  score: 305000
+- name: TAoE WEB
+  score: 305000
+- name: Vialle WEB
+  score: 305000
+- name: Weasley WEB
+  score: 305000
+- name: 1080p Efficient TV WEB Tier 2
+  score: 304000
+- name: 1080p Efficient TV WEB Tier 3
+  score: 303000
+- name: 1080p Efficient TV WEB Tier 4
+  score: 302000
+- name: 1080p Efficient TV Bluray Tier 6
+  score: 301000
+- name: 1080p Efficient TV WEB Tier 5
+  score: 300000
+- name: Season Pack
+  score: 10
+- name: Remux (Source)
+  score: -999999
+- name: TV Extras
+  score: -999999
+- name: Upscaled
+  score: -999999
+qualities:
+- id: -1
+  name: 1080p Efficient
+  description: Balanced Capable releases. Typically WEB-DL would be the overwhelming
+    majority of releases, but there are occasional streaming optimised encodes that
+    should be preferred.
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 9
+    name: WEBDL-1080p
+  - id: 11
+    name: WEBRip-1080p
+- id: -2
+  name: 720p Quality
+  description: Fallback to 720p when 1080p cannot be found.
+  qualities:
+  - id: 13
+    name: Bluray-720p
+  - id: 14
+    name: WEBDL-720p
+  - id: 15
+    name: WEBRip-720p
+- id: -3
+  name: 480p Quality
+  description: Standard Definition Fallbacks
+  qualities:
+  - id: 17
+    name: Bluray-576p
+  - id: 18
+    name: Bluray-480p
+  - id: 19
+    name: WEBDL-480p
+  - id: 22
+    name: DVD
+upgrade_until:
+  id: -1
+  name: 1080p Efficient
+  description: Balanced Capable releases. Typically WEB-DL would be the overwhelming
+    majority of releases, but there are occasional streaming optimised encodes that
+    should be preferred.
+language: must_original

--- a/profiles/FR - 1080p VO-VF Efficient.yml
+++ b/profiles/FR - 1080p VO-VF Efficient.yml
@@ -1,0 +1,348 @@
+name: FR - 1080p VO-VF Efficient
+description: '1080p Efficient targeting MULTi releases only (VO+VF). Based on 1080p
+  Efficient.
+
+
+  - Only MULTi releases are accepted (no fallback to VO-only)
+
+  - VF-only releases are hard-blocked
+
+  - Average TV Sizes ~ 2 to 3gb per Episode'
+tags:
+- 1080p
+- Efficient Focused
+- Lossy Audio
+- h265
+- x265
+- French
+upgradesAllowed: true
+minCustomFormatScore: 20000
+upgradeUntilScore: 888888
+minScoreIncrement: 1
+custom_formats:
+- name: 1080p Bluray HEVC Tier 1
+  score: 360000
+- name: HONE Bluray
+  score: 360000
+- name: 1080p WEB-DL HEVC Tier 1
+  score: 340000
+- name: HONE WEB
+  score: 340000
+- name: 1080p WEB-DL (h264)
+  score: 280000
+- name: 720p WEB-DL
+  score: 240000
+- name: 720p Bluray
+  score: 180000
+- name: 720p WEBRip
+  score: 180000
+- name: 576p Bluray
+  score: 120000
+- name: 720p Quality Tier 1
+  score: 85000
+- name: 720p Quality Tier 2
+  score: 84000
+- name: 720p Quality Tier 3
+  score: 83000
+- name: 720p Quality Tier 4
+  score: 82000
+- name: 720p Quality Tier 5
+  score: 81000
+- name: 480p Bluray
+  score: 80000
+- name: 720p Quality Tier 6
+  score: 80000
+- name: 480p WEB-DL
+  score: 60000
+- name: 576p Quality Tier 1
+  score: 43000
+- name: 576p Quality Tier 2
+  score: 42000
+- name: 576p Quality Tier 3
+  score: 41000
+- name: 576p Quality Tier 4
+  score: 40000
+- name: 480p Quality Tier 1
+  score: 23000
+- name: 480p Quality Tier 2
+  score: 22000
+- name: 480p Quality Tier 3
+  score: 21000
+- name: 480p Quality Tier 4
+  score: 20000
+- name: DVD
+  score: 20000
+- name: DVD Remux
+  score: 20000
+- name: SD Quality Tier 1
+  score: 11000
+- name: SD Quality Tier 2
+  score: 10000
+- name: FR - Multi
+  score: 5000
+- name: AMZN
+  score: 3000
+- name: Dolby Vision
+  score: 3000
+- name: DSNP
+  score: 3000
+- name: ATVP
+  score: 2000
+- name: HDR10+
+  score: 2000
+- name: HMAX
+  score: 2000
+- name: MAX
+  score: 2000
+- name: DS4K
+  score: 1000
+- name: HDR
+  score: 1000
+- name: HDR10
+  score: 1000
+- name: HLG
+  score: 1000
+- name: iT
+  score: 1000
+- name: NF
+  score: 1000
+- name: PQ
+  score: 1000
+- name: FLAC
+  score: 800
+- name: DTS-HD HRA
+  score: 700
+- name: Opus
+  score: 700
+- name: Dolby Digital +
+  score: 600
+- name: DTS-ES
+  score: 500
+- name: Dolby Atmos
+  score: 400
+- name: Dolby Digital
+  score: 400
+- name: DTS
+  score: 300
+- name: AAC
+  score: 200
+- name: WEB-DL Tier 1
+  score: 100
+- name: WEB-DL Tier 2
+  score: 80
+- name: WEB-DL Tier 3
+  score: 60
+- name: WEB-DL Tier 4
+  score: 40
+- name: WEB-DL Tier 5
+  score: 20
+- name: Repack3
+  score: 8
+- name: Repack2
+  score: 7
+- name: Repack1
+  score: 6
+- name: CRAV
+  score: 0
+- name: CRIT
+  score: 0
+- name: DRPO
+  score: 0
+- name: HTSR
+  score: 0
+- name: HULU
+  score: 0
+- name: iP
+  score: 0
+- name: MUBI
+  score: 0
+- name: NOW
+  score: 0
+- name: PCOK
+  score: 0
+- name: PLAY
+  score: 0
+- name: PMTP
+  score: 0
+- name: ROKU
+  score: 0
+- name: SHO
+  score: 0
+- name: STAN
+  score: 0
+- name: ASL
+  score: -999999
+- name: AV1
+  score: -999999
+- name: Banned Groups (Efficient)
+  score: -999999
+- name: Banned WEBRip (Efficient)
+  score: -999999
+- name: BCORE
+  score: -999999
+- name: Dolby Vision (Without Fallback)
+  score: -999999
+- name: FR - Not Multi
+  score: -999999
+- name: FR - VF Only
+  score: -999999
+- name: FR - VFQ
+  score: -999999
+- name: Full Disc
+  score: -999999
+- name: h265 (Efficient)
+  score: -999999
+- name: Lossless Audio
+  score: -999999
+- name: Remux
+  score: -999999
+- name: VP9
+  score: -999999
+- name: VVC
+  score: -999999
+- name: x265 (Efficient)
+  score: -999999
+- name: Xvid
+  score: -999999
+custom_formats_radarr:
+- name: 1080p Efficient Movie Bluray Tier 1
+  score: 323000
+- name: QxR Bluray
+  score: 323000
+- name: TAoE Bluray
+  score: 323000
+- name: 1080p Efficient Movie Bluray Tier 2
+  score: 322000
+- name: Vialle Bluray
+  score: 322000
+- name: 1080p Efficient Movie Bluray Tier 3
+  score: 321000
+- name: 1080p Efficient Movie Bluray Tier 4
+  score: 320000
+- name: 1080p Efficient Movie WEB Tier 1
+  score: 303000
+- name: QxR WEB
+  score: 303000
+- name: TAoE WEB
+  score: 303000
+- name: Weasley WEB
+  score: 303000
+- name: 1080p Efficient Movie WEB Tier 2
+  score: 302000
+- name: 1080p Efficient Movie WEB Tier 3
+  score: 301000
+- name: 1080p Efficient Movie WEB Tier 4
+  score: 300000
+- name: 1080p Balanced Tier 1
+  score: 281000
+- name: 1080p Balanced Tier 2
+  score: 280000
+- name: 720p Balanced Tier 1
+  score: 60000
+- name: MA
+  score: 4000
+- name: Better Theatricals
+  score: 1000
+- name: Special Edition
+  score: 1000
+- name: 3D
+  score: -999999
+- name: B&W
+  score: -999999
+- name: Extras
+  score: -999999
+- name: Full Disc (Quality Match)
+  score: -999999
+- name: Remux (Quality Match)
+  score: -999999
+- name: Sing Along
+  score: -999999
+- name: Upscale
+  score: -999999
+custom_formats_sonarr:
+- name: 1080p Efficient TV Bluray Tier 1
+  score: 324000
+- name: QxR Bluray
+  score: 324000
+- name: TAoE Bluray
+  score: 324000
+- name: Vialle Bluray
+  score: 324000
+- name: 1080p Efficient TV Bluray Tier 2
+  score: 323000
+- name: 1080p Efficient TV Bluray Tier 3
+  score: 322000
+- name: 1080p Efficient TV Bluray Tier 4
+  score: 321000
+- name: 1080p Efficient TV Bluray Tier 5
+  score: 320000
+- name: 1080p Efficient TV WEB Tier 1
+  score: 305000
+- name: QxR WEB
+  score: 305000
+- name: TAoE WEB
+  score: 305000
+- name: Vialle WEB
+  score: 305000
+- name: Weasley WEB
+  score: 305000
+- name: 1080p Efficient TV WEB Tier 2
+  score: 304000
+- name: 1080p Efficient TV WEB Tier 3
+  score: 303000
+- name: 1080p Efficient TV WEB Tier 4
+  score: 302000
+- name: 1080p Efficient TV Bluray Tier 6
+  score: 301000
+- name: 1080p Efficient TV WEB Tier 5
+  score: 300000
+- name: Season Pack
+  score: 10
+- name: Remux (Source)
+  score: -999999
+- name: TV Extras
+  score: -999999
+- name: Upscaled
+  score: -999999
+qualities:
+- id: -1
+  name: 1080p Efficient
+  description: Balanced Capable releases. Typically WEB-DL would be the overwhelming
+    majority of releases, but there are occasional streaming optimised encodes that
+    should be preferred.
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 9
+    name: WEBDL-1080p
+  - id: 11
+    name: WEBRip-1080p
+- id: -2
+  name: 720p Quality
+  description: Fallback to 720p when 1080p cannot be found.
+  qualities:
+  - id: 13
+    name: Bluray-720p
+  - id: 14
+    name: WEBDL-720p
+  - id: 15
+    name: WEBRip-720p
+- id: -3
+  name: 480p Quality
+  description: Standard Definition Fallbacks
+  qualities:
+  - id: 17
+    name: Bluray-576p
+  - id: 18
+    name: Bluray-480p
+  - id: 19
+    name: WEBDL-480p
+  - id: 22
+    name: DVD
+upgrade_until:
+  id: -1
+  name: 1080p Efficient
+  description: Balanced Capable releases. Typically WEB-DL would be the overwhelming
+    majority of releases, but there are occasional streaming optimised encodes that
+    should be preferred.
+language: any

--- a/regex_patterns/FR - Multi.yml
+++ b/regex_patterns/FR - Multi.yml
@@ -1,0 +1,25 @@
+name: FR - Multi
+pattern: (?i)\b(MULTI)\b
+description: Matches releases tagged MULTi (multiple audio tracks, typically VO+VF)
+tags:
+- Language
+- French
+tests:
+- id: 1
+  input: Movie.2024.MULTi.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 2
+  input: Movie.2024.MULTI.1080p.BluRay.x265-GROUP
+  expected: true
+- id: 3
+  input: Movie.2024.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 4
+  input: Movie.2024.FRENCH.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 5
+  input: Movie.2024.MULTi.2160p.UHD.BluRay.x265-GROUP
+  expected: true
+- id: 6
+  input: MultiVerse.2024.1080p.WEB-DL.x265-GROUP
+  expected: false

--- a/regex_patterns/FR - VF.yml
+++ b/regex_patterns/FR - VF.yml
@@ -1,0 +1,35 @@
+name: FR - VF
+pattern: (?i)\b(VFF|VFI|VF2|TRUEFRENCH|FRENCH|VF)\b
+description: Matches French version markers in release titles (VFF, VFI, VF2, TRUEFRENCH,
+  FRENCH, VF)
+tags:
+- Language
+- French
+tests:
+- id: 1
+  input: Movie.2024.VFF.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 2
+  input: Movie.2024.FRENCH.1080p.BluRay.x265-GROUP
+  expected: true
+- id: 3
+  input: Movie.2024.TRUEFRENCH.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 4
+  input: Movie.2024.VFQ.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 5
+  input: Movie.2024.VFI.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 6
+  input: Movie.2024.VF2.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 7
+  input: Movie.2024.VF.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 8
+  input: Movie.2024.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 9
+  input: Movie.2024.MULTi.1080p.WEB-DL.x265-GROUP
+  expected: false

--- a/regex_patterns/FR - VFQ.yml
+++ b/regex_patterns/FR - VFQ.yml
@@ -1,0 +1,22 @@
+name: FR - VFQ
+pattern: (?i)\b(VFQ)\b
+description: Matches Quebec French version marker (VFQ) in release titles
+tags:
+- Language
+- French
+tests:
+- id: 1
+  input: Movie.2024.VFQ.1080p.WEB-DL.x265-GROUP
+  expected: true
+- id: 2
+  input: Movie.2024.VFF.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 3
+  input: Movie.2024.FRENCH.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 4
+  input: Movie.2024.MULTi.1080p.WEB-DL.x265-GROUP
+  expected: false
+- id: 5
+  input: Movie.2024.1080p.WEB-DL.x265-GROUP
+  expected: false


### PR DESCRIPTION
## Why

Add comprehensive French language support for 1080p Efficient profiles. Provides two targeted configurations for users preferring specific audio track combinations, with hard-blocking of Quebec French versions unsuitable for European French audiences.

## What

- 3 regex patterns: FR - Multi, FR - VF, FR - VFQ with test coverage
- 4 custom formats to identify and filter French releases
- 2 profiles for flexible audio preferences:
  - FR - 1080p VO-VF Efficient: Accepts Multi-only releases (blocks non-Multi and VF-only)
  - FR - 1080p VO Efficient: Accepts Multi and VO releases (blocks VF-only)
- VFQ (Quebec French) hard-blocked in both profiles (score -999999)
- Project documentation (CLAUDE.md)